### PR TITLE
cookieに保存したIDトークンからユーザ情報取得

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,7 +2,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 #from fastapi.middleware.cors import CORSMiddleware
 
-from routers import gpt, location, auth, nft
+from routers import gpt, location, auth, nft, user
 from utils.config import check_env_variables
 
 
@@ -21,6 +21,7 @@ app.include_router(location.router)
 app.include_router(gpt.router)
 app.include_router(auth.router)
 app.include_router(nft.router)
+app.include_router(user.router)
 
 
 """

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "sqlmodel>=0.0.22",
     "pymysql>=1.1.1",
     "aiomysql>=0.2.0",
+    "pyjwt>=2.10.1",
 ]
 
 [dependency-groups]

--- a/backend/routers/user.py
+++ b/backend/routers/user.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, Cookie
+from services.line import get_user_id, get_profile
+
+
+router = APIRouter()
+
+
+@router.get("/users/me")
+async def login(id_token: str = Cookie(None)):
+    if id_token:
+        user_id = get_user_id(id_token)
+        profile = get_profile(id_token)
+        return { "id": user_id, **profile }
+    return {"message": "No cookie received"}

--- a/backend/services/line.py
+++ b/backend/services/line.py
@@ -1,5 +1,6 @@
 import httpx
 from utils.config import get_line_client_id, get_line_client_secret, get_line_redirect_uri
+from utils.jwt import decode_hs256
 
 CLIENT_ID = get_line_client_id()
 CLIENT_SECRET = get_line_client_secret()
@@ -22,14 +23,24 @@ async def get_token(code: str):
         return response.json()
 
 
-async def get_profile(id_token):
-    # LINE API の IDトークン検証エンドポイント
-    url = "https://api.line.me/oauth2/v2.1/verify"
+def get_user_id(id_token):
+    decoded_token = decode_hs256(id_token, CLIENT_ID, CLIENT_SECRET)
+    return decoded_token["sub"]
 
-    # リクエストのペイロード
+
+def get_profile(id_token):
+    decoded_token = decode_hs256(id_token, CLIENT_ID, CLIENT_SECRET)
+    return {
+        "name": decoded_token["name"],
+        "picture": decoded_token["picture"]
+    }
+
+
+async def get_profile_by_endpoint(id_token):
+    url = "https://api.line.me/oauth2/v2.1/verify"
     data = {
-        "id_token": id_token,  # 取得済みのIDトークン
-        "client_id": CLIENT_ID,  # LINE DevelopersコンソールのチャンネルID
+        "id_token": id_token,
+        "client_id": CLIENT_ID,
     }
     async with httpx.AsyncClient() as client:
         response = await client.post(url, data=data)

--- a/backend/utils/jwt.py
+++ b/backend/utils/jwt.py
@@ -1,0 +1,14 @@
+from jwt import decode, InvalidTokenError
+
+
+def decode_hs256(token: str, client_id: str, client_secret: id):
+    try:
+        decoded_token = decode(
+            jwt=token,
+            key=client_secret,
+            algorithms=["HS256"],
+            audience=client_id
+        )
+        return decoded_token
+    except InvalidTokenError as e:
+        raise f"トークンの検証に失敗しました: {str(e)}"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -826,6 +826,7 @@ dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
     { name = "openai" },
+    { name = "pyjwt" },
     { name = "pymysql" },
     { name = "requests" },
     { name = "sqlmodel" },
@@ -846,6 +847,7 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.4" },
     { name = "httpx", specifier = ">=0.27.2" },
     { name = "openai", specifier = ">=1.55.0" },
+    { name = "pyjwt", specifier = ">=2.10.1" },
     { name = "pymysql", specifier = ">=1.1.1" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "sqlmodel", specifier = ">=0.0.22" },
@@ -1057,6 +1059,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199", size = 4891905 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a", size = 1205513 },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997 },
 ]
 
 [[package]]

--- a/frontend/src/plugin/axios.js
+++ b/frontend/src/plugin/axios.js
@@ -2,15 +2,11 @@ import axios from 'axios';
 
 const apiAxios = axios.create({
   timeout: 5000,
+  withCredentials: true
 });
 
 apiAxios.interceptors.request.use(
   (config) => {
-    // 例: Authorizationヘッダーを追加
-    const token = localStorage.getItem('token');
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
     return config;
   },
   (error) => Promise.reject(error)

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -2,10 +2,12 @@ import { createRouter, createWebHistory } from "vue-router"
 
 import Login from "./views/Login.vue"
 import Location from "./views/Location.vue"
+import User from "./views/User.vue"
 
 const routes = [
   { path: "/", component: Login },
-  { path: "/location", component: Location }
+  { path: "/location", component: Location },
+  { path: "/user", component: User },
 ]
 
 const router = createRouter({

--- a/frontend/src/views/User.vue
+++ b/frontend/src/views/User.vue
@@ -1,0 +1,39 @@
+<script setup>
+import { ref, onMounted } from 'vue';
+import apiAxios from "@/plugin/axios";
+
+const user = ref(null);
+const loading = ref(true); // ローディング状態
+const error = ref(null); // エラー情報
+
+const fetchUser = async () => {
+  try {
+    const response = await apiAxios.get('/api/users/me');
+    user.value = response.data;
+  } catch (err) {
+    error.value = 'Failed to load user information.';
+    console.error(err);
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(() => {
+  fetchUser();
+});
+</script>
+
+
+<template>
+  <div>
+    <h1>User Information</h1>
+    <div v-if="loading">Loading...</div>
+    <div v-else-if="error">{{ error }}</div>
+    <div v-else>
+      <p><strong>ID:</strong> {{ user.id }}</p>
+      <p><strong>Name:</strong> {{ user.name }}</p>
+      <img :src="user.picture" alt="profile">
+    </div>
+  </div>
+</template>
+


### PR DESCRIPTION
## 概要
バックエンドサーバ側でjwtをデコードして、クライアントに返します。

## 関連タスク
Close #34 (required)

## やったこと
- `/api/users/me`でユーザ情報取得
- クライアント側からcookieを送信
- `/utils/jwt.py`でjwtのデコード

## やらないこと
- DBへのユーザ追加

## レビュー事項
-

## 補足 参考情報


