### PR TITLE
cookieがないのに、ログインボタンが出ない問題を解決

### DIFF
--- a/backend/routers/user.py
+++ b/backend/routers/user.py
@@ -2,11 +2,13 @@ from fastapi import APIRouter, Cookie, Depends, HTTPException
 from sqlmodel.ext.asyncio.session import AsyncSession
 from database import get_db
 from models.user import User
-from services.line import get_user_id, get_profile, get_user_id_from_cookie
+from services.line import get_profile, get_user_id_from_cookie
+from utils.logging import get_logger
 
 import cruds.user as user_crud
 
 router = APIRouter()
+logger = get_logger()
 
 
 @router.get(
@@ -30,12 +32,11 @@ async def get_user(
     tags=["users"],
     summary="プロフィール情報取得",
 )
-async def login(id_token: str = Cookie(None)):
-    if id_token:
-        user_id = get_user_id(id_token)
-        profile = get_profile(id_token)
-        return {"id": user_id, **profile}
-    return {"message": "No cookie received"}
+def login(id_token: str = Cookie(None)):
+    if id_token is None:
+        raise HTTPException(status_code=401, detail="No id_token received")
+    profile = get_profile(id_token)
+    return profile
 
 
 @router.post(

--- a/backend/utils/logging.py
+++ b/backend/utils/logging.py
@@ -1,0 +1,22 @@
+import logging
+
+# ロガーの設定
+logger = logging.getLogger("api")
+logger.setLevel(logging.DEBUG)
+
+
+# コンソール出力の設定
+console_handler = logging.StreamHandler()
+console_handler.setLevel(logging.INFO)
+
+# フォーマットの設定
+formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+console_handler.setFormatter(formatter)
+
+# ハンドラの設定
+logger.addHandler(console_handler)
+
+
+# 他のモジュールで使うための公開用ロガー
+def get_logger():
+    return logger

--- a/nginx.conf
+++ b/nginx.conf
@@ -3,6 +3,11 @@ events {
 }
 
 http {
+  # Access log を無効化
+  access_log off;
+
+  # Error log を無効化または特定レベルに設定
+  error_log /dev/null crit;
   server {
       listen 443 ssl;
       server_name localhost;


### PR DESCRIPTION
## 概要
タイトルの通り

## 関連タスク
Close #81 (required)

## やったこと
- nginxのログをオフ
- pythonのlogging 導入
- /routers/user.py の修正
    - 非同期関数 -> 同期関数
    - /users/me/profile で、idを返さないようにした。
    - エラーハンドリングの改善 `if id_token is None:`

## やらないこと


## レビュー事項
-

## 補足 参考情報


