### PR TITLE
データベース機能の追加

### DIFF
--- a/backend/cruds/nft.py
+++ b/backend/cruds/nft.py
@@ -10,8 +10,8 @@ async def create_nft(db: AsyncSession, nft: Nft) -> Nft:
     return nft
 
 
-async def get_nft(db: AsyncSession, nft_id: str) -> Optional[Nft]:
-    return await db.get(Nft, nft_id)
+async def get_nft(db: AsyncSession, id: str) -> Optional[Nft]:
+    return await db.get(Nft, id)
 
 
 async def update_nft(db: AsyncSession, nft: Nft) -> Nft:

--- a/backend/cruds/nft.py
+++ b/backend/cruds/nft.py
@@ -1,6 +1,7 @@
 from sqlmodel.ext.asyncio.session import AsyncSession
 from models.nft import Nft
 from typing import Optional
+from sqlalchemy.future import select
 
 
 async def create_nft(db: AsyncSession, nft: Nft) -> Nft:

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,10 +1,12 @@
-from typing import Optional,List,TYPE_CHECKING
-from sqlmodel import Field, SQLModel,Relationship
+from typing import Optional, List, TYPE_CHECKING
+from sqlmodel import Field, SQLModel, Relationship
 from datetime import datetime
 from models.nft import Nft
 
 if TYPE_CHECKING:
     from models.nft import Nft
+
+
 class User(SQLModel, table=True):
     id: str = Field(
         ..., primary_key=True, index=True, max_length=33,

--- a/backend/routers/nft.py
+++ b/backend/routers/nft.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter,UploadFile,Body
-import os
+from fastapi import APIRouter, UploadFile, Depends
+from sqlmodel.ext.asyncio.session import AsyncSession
 from fastapi import APIRouter, HTTPException
+from database import get_db
 from schemas.nft_schema import NFTMetadata
 from services.nft_service import (
     upload_image_to_pinata,
@@ -13,33 +14,36 @@ from services.nft_service import (
 from utils.config import (
     get_nft_private_key
 )
+from models.nft import Nft  
+import cruds.nft as nft_crud
+from models.nft import Nft  
+from services.line import get_user_id_from_cookie
 
 NFT_PRIVATE_KEY = get_nft_private_key()
 
 router = APIRouter()
 
+
 @router.post(
     "/nft",
     tags=["NFT"],
-    summary="画像のアップロードとNFTの発行",
+    summary="画像のアップロードとNFTの発行"
 )
-async def mint(upload_file: UploadFile):
-    # Pinataに画像をアップロードしてURLを取得
+async def mint(upload_file: UploadFile,
+               db: AsyncSession = Depends(get_db)
+               ):
     image_url = await upload_image_to_pinata(upload_file)
-    # メタデータの作成
-    nft_metadata = create_metadata(filename=upload_file.filename,image_url=image_url)
+    nft_metadata = create_metadata(
+        filename=upload_file.filename, image_url=image_url)
     metadata_url = upload_metadata_to_pinata(nft_metadata)
-    # NFTをブロックチェーンにミント
-    tx_receipt = mint_nft(metadata_url,NFT_PRIVATE_KEY)
-    # トランザクションハッシュを取得
+    tx_receipt = mint_nft(metadata_url, NFT_PRIVATE_KEY)
     tx_hash = tx_receipt.transactionHash.hex()
-    # イベントログからトークンIDを取得
     try:
-        token_id_hex = tx_receipt.logs[0]["topics"][3]  # トークンIDのHexBytes
-        token_id = int(token_id_hex.hex(), 16)  # 16進数を整数に変換
+        token_id_hex = tx_receipt.logs[0]["topics"][3]
+        token_id = int(token_id_hex.hex(), 16)
     except (KeyError, IndexError) as e:
-        raise HTTPException(status_code=500, detail=f"Failed to retrieve token ID: {str(e)}")
-
+        raise HTTPException(
+            status_code=500, detail=f"Failed to retrieve token ID: {str(e)}")
 
     response_data = {
         "name": nft_metadata.name,
@@ -50,8 +54,13 @@ async def mint(upload_file: UploadFile):
         "tokenId": token_id
     }
 
-    #メタデータと取引情報を返す
+    existing_nft = await nft_crud.get_user(db, tx_hash)
+    if existing_nft:
+        raise HTTPException(status_code=400, detail="NFT already exists")
+    nft = Nft(id=tx_hash, user_id=get_user_id_from_cookie())
+    await nft_crud.create_nft(db, nft)
     return response_data
+
 
 @router.get(
     "/nft/metadata/{tx_hash}",
@@ -65,7 +74,8 @@ async def get_nft_metadata(tx_hash: str):
     except HTTPException as e:
         raise e
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error occurred: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Error occurred: {str(e)}")
 
 
 @router.get(
@@ -75,7 +85,8 @@ async def get_nft_metadata(tx_hash: str):
 )
 async def balance():
     try:
-        balance = get_balance()  
-        return balance  
+        balance = get_balance()
+        return balance
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error occurred: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Error occurred: {str(e)}")

--- a/backend/routers/nft_database.py
+++ b/backend/routers/nft_database.py
@@ -39,7 +39,7 @@ async def create_nft_endpoint(
     existing_nft = await nft_crud.get_nft(db, nft_id)
     if existing_nft:
         raise HTTPException(status_code=400, detail="Nft already exists")
-    nft = Nft(id=nft_id,user_id=user_id)
+    nft = Nft(id=nft_id, user_id=user_id)
     return await nft_crud.create_nft(db, nft)
 
 

--- a/backend/routers/nft_database.py
+++ b/backend/routers/nft_database.py
@@ -25,7 +25,7 @@ async def get_nft(
 
 
 @router.post(
-    "/nft",
+    "/nfttest",
     tags=["NFT"],
     summary="NFTをデータベースに追加する",
     response_model=Nft,
@@ -39,7 +39,7 @@ async def create_nft_endpoint(
     existing_nft = await nft_crud.get_nft(db, nft_id)
     if existing_nft:
         raise HTTPException(status_code=400, detail="Nft already exists")
-    nft = Nft(nft_id=nft_id,user_id=user_id)
+    nft = Nft(id=nft_id,user_id=user_id)
     return await nft_crud.create_nft(db, nft)
 
 

--- a/backend/services/nft_service.py
+++ b/backend/services/nft_service.py
@@ -10,13 +10,20 @@ from utils.config import (
     get_pinata_secret_api_key,
     get_nft_private_key
 )
+from models.nft import Nft
+from cruds.nft import (
+    create_nft,
+    get_nft,
+    update_nft,
+    delete_nft,
+)
 
-PINATA_API_KEY=get_pinata_api_key()
-PINATA_SECRET_API_KEY=get_pinata_secret_api_key()
-NFT_ACCOUNT_ADDRESS=get_nft_acount_address()
-NFT_PRIVATE_KEY=get_nft_private_key()
+PINATA_API_KEY = get_pinata_api_key()
+PINATA_SECRET_API_KEY = get_pinata_secret_api_key()
+NFT_ACCOUNT_ADDRESS = get_nft_acount_address()
+NFT_PRIVATE_KEY = get_nft_private_key()
 
-NFT_NETWORK_URL="https://polygon-rpc.com/"
+NFT_NETWORK_URL = "https://polygon-rpc.com/"
 
 web3 = Web3(Web3.HTTPProvider(NFT_NETWORK_URL))
 web3.eth.default_account = get_nft_acount_address()
@@ -28,7 +35,6 @@ with open("/app/services/HackuNFT_abi.json", "r") as abi_file:
 
 contract_address = "0xfB40b73E6cEe109Ae7614e621ffA841Dd1EB1584"  # デプロイ済みのコントラクトアドレス
 contract = web3.eth.contract(address=contract_address, abi=abi)
-
 
 
 # Pinataへのアップロード関数
@@ -43,21 +49,25 @@ async def upload_image_to_pinata(upload_file: UploadFile):
 
         # ファイルデータを送信
         files = {"file": (upload_file.filename, file_content)}
-        response = requests.post("https://api.pinata.cloud/pinning/pinFileToIPFS", headers=headers, files=files)
+        response = requests.post(
+            "https://api.pinata.cloud/pinning/pinFileToIPFS", headers=headers, files=files)
 
         # レスポンスを処理
         if response.status_code == 200:
             response_data = response.json()
             ipfs_hash = response_data["IpfsHash"]
             return f"https://gateway.pinata.cloud/ipfs/{ipfs_hash}"
-        else: 
+        else:
             raise HTTPException(
                 status_code=500, detail=f"Failed to upload file: {response.text}"
             )
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error occurred: {str(e)}")
-    
+        raise HTTPException(
+            status_code=500, detail=f"Error occurred: {str(e)}")
+
 # メタデータをPinataにアップロードする関数
+
+
 def upload_metadata_to_pinata(metadata):
     try:
         headers = {
@@ -66,20 +76,25 @@ def upload_metadata_to_pinata(metadata):
             "Content-Type": "application/json",
         }
 
-        #Pydanticモデルを辞書に変換
+        # Pydanticモデルを辞書に変換
         metadata_dict = json.loads(metadata.json(by_alias=True))
-        response = requests.post("https://api.pinata.cloud/pinning/pinJSONToIPFS", headers=headers, json=metadata_dict)
+        response = requests.post(
+            "https://api.pinata.cloud/pinning/pinJSONToIPFS", headers=headers, json=metadata_dict)
 
         if response.status_code == 200:
             response_data = response.json()
             ipfs_hash = response_data["IpfsHash"]
             return f"https://gateway.pinata.cloud/ipfs/{ipfs_hash}"
         else:
-            raise HTTPException(status_code=500, detail=f"Failed to upload metadata: {response.text}")
+            raise HTTPException(
+                status_code=500, detail=f"Failed to upload metadata: {response.text}")
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error occurred: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Error occurred: {str(e)}")
 
 # NFT Mint関数
+
+
 def mint_nft(metadata_url, private_key):
     try:
         # ガス価格とnonceを取得
@@ -89,21 +104,21 @@ def mint_nft(metadata_url, private_key):
         # トランザクションの構築
         transaction = contract.functions.createNFT(metadata_url).build_transaction({
             "from": NFT_ACCOUNT_ADDRESS,
-            #"chainId": 137,
+            # "chainId": 137,
             "chainId": 137,
             "gas": 5000000,  # ガスリミット
             "gasPrice": gas_price,  # 動的なガス価格
             "nonce": nonce,  # nonceを明示的に設定
         })
-        signed_txn = web3.eth.account.sign_transaction(transaction, private_key=private_key)
+        signed_txn = web3.eth.account.sign_transaction(
+            transaction, private_key=private_key)
         tx_hash = web3.eth.send_raw_transaction(signed_txn.raw_transaction)
         tx_receipt = web3.eth.wait_for_transaction_receipt(tx_hash)
 
         return tx_receipt
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error occurred during NFT minting: {str(e)}")
-
-
+        raise HTTPException(
+            status_code=500, detail=f"Error occurred during NFT minting: {str(e)}")
 
 
 def get_metadata_from_transaction(tx_hash: str):
@@ -132,22 +147,25 @@ def get_metadata_from_transaction(tx_hash: str):
                 status_code=500, detail=f"Failed to retrieve metadata: {response.text}"
             )
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error occurred: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Error occurred: {str(e)}")
+
 
 def get_balance():
     web3 = Web3(Web3.HTTPProvider(NFT_NETWORK_URL))
     balance = web3.eth.get_balance(NFT_ACCOUNT_ADDRESS)
-    return {"balance": {balance}, 
+    return {"balance": {balance},
             "currency": "POL"}
 
-def create_metadata(filename:str,image_url:str):
+
+def create_metadata(filename: str, image_url: str):
     meta_data = nft_metadata = NFTMetadata(
-                    name=filename,
-                    description="2024年 NFT with 神により、生成されたおみくじです。",
-                    image=image_url,
-                    attributes=[
-                        {"trait_type": "Year", "value": "2024"},
-                        {"trait_type": "Grade", "value": "Super"},
-                    ],
-                )
+        name=filename,
+        description="2024年 NFT with 神により、生成されたおみくじです。",
+        image=image_url,
+        attributes=[
+            {"trait_type": "Year", "value": "2024"},
+            {"trait_type": "Grade", "value": "Super"},
+        ],
+    )
     return meta_data

--- a/backend/services/nft_service.py
+++ b/backend/services/nft_service.py
@@ -37,22 +37,18 @@ contract_address = "0xfB40b73E6cEe109Ae7614e621ffA841Dd1EB1584"  # デプロイ�
 contract = web3.eth.contract(address=contract_address, abi=abi)
 
 
-# Pinataへのアップロード関数
 async def upload_image_to_pinata(upload_file: UploadFile):
     try:
         file_content = await upload_file.read()
-        # ヘッダーを設定
         headers = {
             "pinata_api_key": PINATA_API_KEY,
             "pinata_secret_api_key": PINATA_SECRET_API_KEY,
         }
 
-        # ファイルデータを送信
         files = {"file": (upload_file.filename, file_content)}
         response = requests.post(
             "https://api.pinata.cloud/pinning/pinFileToIPFS", headers=headers, files=files)
 
-        # レスポンスを処理
         if response.status_code == 200:
             response_data = response.json()
             ipfs_hash = response_data["IpfsHash"]
@@ -65,8 +61,6 @@ async def upload_image_to_pinata(upload_file: UploadFile):
         raise HTTPException(
             status_code=500, detail=f"Error occurred: {str(e)}")
 
-# メタデータをPinataにアップロードする関数
-
 
 def upload_metadata_to_pinata(metadata):
     try:
@@ -76,7 +70,6 @@ def upload_metadata_to_pinata(metadata):
             "Content-Type": "application/json",
         }
 
-        # Pydanticモデルを辞書に変換
         metadata_dict = json.loads(metadata.json(by_alias=True))
         response = requests.post(
             "https://api.pinata.cloud/pinning/pinJSONToIPFS", headers=headers, json=metadata_dict)
@@ -92,23 +85,18 @@ def upload_metadata_to_pinata(metadata):
         raise HTTPException(
             status_code=500, detail=f"Error occurred: {str(e)}")
 
-# NFT Mint関数
-
 
 def mint_nft(metadata_url, private_key):
     try:
-        # ガス価格とnonceを取得
         gas_price = web3.eth.gas_price
         nonce = web3.eth.get_transaction_count(NFT_ACCOUNT_ADDRESS, "pending")
 
-        # トランザクションの構築
         transaction = contract.functions.createNFT(metadata_url).build_transaction({
             "from": NFT_ACCOUNT_ADDRESS,
-            # "chainId": 137,
             "chainId": 137,
-            "gas": 5000000,  # ガスリミット
-            "gasPrice": gas_price,  # 動的なガス価格
-            "nonce": nonce,  # nonceを明示的に設定
+            "gas": 5000000,
+            "gasPrice": gas_price,
+            "nonce": nonce,
         })
         signed_txn = web3.eth.account.sign_transaction(
             transaction, private_key=private_key)
@@ -123,17 +111,13 @@ def mint_nft(metadata_url, private_key):
 
 def get_metadata_from_transaction(tx_hash: str):
     try:
-        # トランザクションの情報を取得
         tx_receipt = web3.eth.get_transaction_receipt(tx_hash)
 
-        # ログからトークンIDを取得
-        token_id_hex = tx_receipt.logs[0]["topics"][3]  # トークンIDは3番目のトピック
-        token_id = int(token_id_hex.hex(), 16)  # 16進数を整数に変換
+        token_id_hex = tx_receipt.logs[0]["topics"][3]
+        token_id = int(token_id_hex.hex(), 16)
 
-        # コントラクトからトークンURI（メタデータURL）を取得
         token_uri = contract.functions.tokenURI(token_id).call()
 
-        # メタデータを取得
         response = requests.get(token_uri)
         if response.status_code == 200:
             metadata = response.json()

--- a/backend/utils/query.py
+++ b/backend/utils/query.py
@@ -1,0 +1,28 @@
+from typing import List, Dict
+from sqlalchemy.future import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from models.nft import Nft
+from services.nft_service import get_metadata_from_transaction
+
+
+async def get_nfts_image_and_time_by_user_id(db: AsyncSession, user_id: str) -> List[Dict[str, str]]:
+    query = select(Nft.id, Nft.created_at).where(Nft.user_id == user_id)
+    result = await db.execute(query)
+
+    nft_data = []
+    for row in result.fetchall():
+        nft_id, created_at = row[0], row[1]
+        try:
+            metadata = get_metadata_from_transaction(nft_id)
+            image_url = metadata["metadata"].get("image", "")
+            nft_data.append({"image_url": image_url, "created_at": created_at})
+        except Exception as e:
+            print(f"Error fetching metadata for NFT ID {nft_id}: {e}")
+            nft_data.append(
+                {"image_url": "Error retrieving metadata", "created_at": created_at})
+
+    nft_data.sort(key=lambda x: x["created_at"], reverse=True)
+    for nft in nft_data:
+        nft["created_at"] = nft["created_at"].strftime("%m/%d %H:%M")
+
+    return nft_data

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -2,11 +2,10 @@
 import { computed, onMounted } from "vue";
 import { useRouter } from "vue-router";
 import { useUserProfileStore } from "@/stores/userProfileStore";
-import LoginButton from "@/components/LoginButton.vue"
+import LoginButton from "@/components/LoginButton.vue";
+import axios from "axios";
 
 const router = useRouter();
-
-// ストアのインスタンスを取得
 const userStore = useUserProfileStore();
 
 // ログイン状態とユーザー情報を取得
@@ -19,14 +18,25 @@ onMounted(() => {
   userStore.fetchUserProfile();
 });
 
-const viewHistory = () => {
-  /* TODO: 実装 */
-}
+// ユーザー登録を行う関数
+const registerUser = async () => {
+  try {
+    const response = await axios.post("/api/users");
+    console.log("ユーザー登録成功:", response.data);
+    alert("ユーザーが正常に登録されました");
+  } catch (error) {
+    console.error("ユーザー登録エラー:", error);
+    alert("ユーザー登録中にエラーが発生しました");
+  }
+};
 
-const handleClick = () => {
-  router.push("/location")
-}
+// ボタンクリック時の処理
+const handleClick = async () => {
+  await registerUser();
+  router.push("/location");
+};
 </script>
+
 
 
 <template>


### PR DESCRIPTION
## 概要


## 関連タスク
Close #109   (required)

## やったこと
-ユーザーログインの際にデータベースへ追加するようにした
-nftを発行する際にデータベースにユーザと紐づけて記憶
-nftデータベースを用いてuser_idからユーザの持つすべてのNFTの画像URLとデータベースに登録された時間を取得
-nft_service.pyのコメントの削除
-formaterをかけた
-フロントエンドでログインしたときにデータベースに追加されるようにしたけどうまくいってないっぽい
## やらないこと
-コードを最適化する


## レビュー事項
-データベースが間違っていないか
-ちゃんと動きました

## 補足 参考情報


