### PR TITLE
NFTがないときのエラーstatusの設定

### DIFF
--- a/backend/routers/nft.py
+++ b/backend/routers/nft.py
@@ -77,7 +77,7 @@ async def get_nft_metadata(tx_hash: str):
         raise e
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Error occurred: {str(e)}")
+            status_code=404, detail="User not found")
 
 
 @router.get(
@@ -91,7 +91,7 @@ async def balance():
         return balance
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Error occurred: {str(e)}")
+            status_code=404, detail="NFT account not found")
 
 
 @router.get(

--- a/backend/utils/query.py
+++ b/backend/utils/query.py
@@ -3,14 +3,17 @@ from sqlalchemy.future import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from models.nft import Nft
 from services.nft_service import get_metadata_from_transaction
+from fastapi import APIRouter, HTTPException
 
 
 async def get_nfts_image_and_time_by_user_id(db: AsyncSession, user_id: str) -> List[Dict[str, str]]:
     query = select(Nft.id, Nft.created_at).where(Nft.user_id == user_id)
     result = await db.execute(query)
-
+    rows = result.fetchall()
+    if not rows:
+        raise HTTPException(status_code=404, detail="No NFTs found for the given user ID")
     nft_data = []
-    for row in result.fetchall():
+    for row in rows:
         nft_id, created_at = row[0], row[1]
         try:
             metadata = get_metadata_from_transaction(nft_id)


### PR DESCRIPTION
## 概要


## 関連タスク
Close #127   (required)

## やったこと
データベースからNFTのデータをとってくるとき、NFTが0だったらエラー404を返すようにした

## やらないこと


## レビュー事項
-

## 補足 参考情報


